### PR TITLE
Add g:swap_disable_default_mappings variable

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -123,3 +123,4 @@ You have the possibility to define your own custom mappings in your _vimrc_:
     nmap <leader>X         <plug>SwapSwapWithL_WORD
 
 _Note:_ You can replace `\x`, `\cx`, `\X` with whatever you like.
+_Note:_ If you want to disable the default mappings, set 1 to `g:swap_disable_default_mappings`.

--- a/plugin/swap.vim
+++ b/plugin/swap.vim
@@ -31,10 +31,12 @@ xmap <silent> <plug>SwapSwapPivotOperands :     call swap#text('vi')<cr>
 nmap <silent> <plug>SwapSwapWithR_WORD    :<c-u>call swap#text('nr')<cr>
 nmap <silent> <plug>SwapSwapWithL_WORD    :<c-u>call swap#text('nl')<cr>
 
-xmap <leader>x  <plug>SwapSwapOperands
-xmap <leader>cx <plug>SwapSwapPivotOperands
-nmap <leader>x  <plug>SwapSwapWithR_WORD
-nmap <leader>X  <plug>SwapSwapWithL_WORD
+if !get(g:, 'swap_disable_default_mappings', 0)
+  xmap <leader>x  <plug>SwapSwapOperands
+  xmap <leader>cx <plug>SwapSwapPivotOperands
+  nmap <leader>x  <plug>SwapSwapWithR_WORD
+  nmap <leader>X  <plug>SwapSwapWithL_WORD
+endif
 
 let &cpoptions = s:savecpo
 unlet s:savecpo


### PR DESCRIPTION
Thanks for the wonderful plugin. I really like it.

Well, I would like to disable default key mappings. That's why I add `g:swap_disable_default_mappings` to control the mapping definition. Could you check it?
