### PR TITLE
Fix Vim crash issue with virtualedit=all

### DIFF
--- a/autoload/swap.vim
+++ b/autoload/swap.vim
@@ -133,6 +133,14 @@ function! swap#text(mode) range
       call histdel('search', -1)
    endif
 
-   call setpos('.', save_cursor)
+   if &virtualedit == 'all' && a:mode =~ 'v'
+      " wrong cursor position is better than crash
+      " https://groups.google.com/forum/#!topic/vim_dev/AK_HZ-5TeuU
+      set virtualedit=
+      call setpos('.', save_cursor)
+      set virtualedit=all
+   else
+      call setpos('.', save_cursor)
+   endif
 
 endfunction


### PR DESCRIPTION
Vim would crash when `setpos` is called with a value obtain from `getpos` if
the `virtualedit=all` is specified.
This is based on a reported bug of Vim but appling patch is quite tough
job for ordinal user, so I change the plugins behavior in the critical
case.

With this commit, the cursor position is not correctly restored when
user select text in visual mode and `virtualedit=all` is specified.
However it is much better than CRASH.
It should not affect the user who does not specify `virtualedit=all` in
them vimrc.

Bug: https://groups.google.com/forum/#!topic/vim_dev/AK_HZ-5TeuU

I'm using `virtualedit=all` thus I made this PR. Please check it :-)
